### PR TITLE
Backpressure support

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function MargaretBatcher(opts) {
     return new MargaretBatcher(opts)
   }
   if (typeof opts !== 'object') opts = {limit:opts} // backward compat
-  Transform.call(this, {objectMode:true})
+  Transform.call(this, {objectMode:true, highWaterMark:2})
   this.limit = opts.limit || 4096 // 4KB, arbitrary
   this.time = opts.time
   this.getLength = opts.length || getLength


### PR DESCRIPTION
We should set a hwm of 2. This allows one batch us to buffer a single batch before write starts returning false and backpressure kicks in when piping.
