### PR TITLE
Ensure time when no writes happen

### DIFF
--- a/test.js
+++ b/test.js
@@ -74,8 +74,8 @@ test('batch after time', function(t) {
   var batcher = batchTest({time:100}, function(err, batches) {
     if (err) throw err
     t.equals(batches.length, 2)
-    t.same(batches[0], ['hel','lo'])
-    t.same(batches[1], ['world'])
+    t.same(batches[0], ['hel'])
+    t.same(batches[1], ['lo', 'world'])
     t.end()
   })
   batcher.write('hel')


### PR DESCRIPTION
This PR changes the time option to use `setTimeout` to make sure that batches are emitted at least every `time` ms even though no writes are happening.
